### PR TITLE
Use HypervisorConfig to enable device plugin for hypervisor

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -389,6 +389,21 @@ func (app *virtHandlerApp) Run() {
 		panic(err)
 	}
 
+	// Bootstrapping. From here on the startup order matters
+
+	factory.Start(stop)
+	go domainSharedInformer.Run(stop)
+
+	cache.WaitForCacheSync(
+		stop,
+		vmiInformer.HasSynced,
+		vmiSourceInformer.HasSynced,
+		vmiTargetInformer.HasSynced,
+		domainSharedInformer.HasSynced,
+		factory.CRD().HasSynced,
+		factory.KubeVirt().HasSynced,
+	)
+
 	vmController, err := virthandler.NewVirtualMachineController(
 		recorder,
 		app.virtCli,
@@ -425,11 +440,6 @@ func (app *virtHandlerApp) Run() {
 	go app.clientcertmanager.Start()
 	go app.servercertmanager.Start()
 
-	// Bootstrapping. From here on the startup order matters
-
-	factory.Start(stop)
-	go domainSharedInformer.Run(stop)
-
 	se, exists, err := selinux.NewSELinux()
 	if err == nil && exists {
 		// relabel tun device
@@ -450,16 +460,6 @@ func (app *virtHandlerApp) Run() {
 		//an error occurred
 		panic(fmt.Errorf("failed to detect the presence of selinux: %v", err))
 	}
-
-	cache.WaitForCacheSync(
-		stop,
-		vmiInformer.HasSynced,
-		vmiSourceInformer.HasSynced,
-		vmiTargetInformer.HasSynced,
-		domainSharedInformer.HasSynced,
-		factory.CRD().HasSynced,
-		factory.KubeVirt().HasSynced,
-	)
 
 	if err := metrics.SetupMetrics(app.VirtShareDir, app.HostOverride, app.MaxRequestsInFlight, vmiSourceInformer, machines); err != nil {
 		panic(err)

--- a/hack/rpm-deps.sh
+++ b/hack/rpm-deps.sh
@@ -3,7 +3,6 @@
 # 2. to keep things simple
 # 3. good enough for our purposes
 
-
 #!/usr/bin/env bash
 
 set -ex

--- a/pkg/hypervisor/hyperv-layered.go
+++ b/pkg/hypervisor/hyperv-layered.go
@@ -35,3 +35,7 @@ func (h *HyperVLayeredHypervisor) AdjustDomain(vmi *v1.VirtualMachineInstance, d
 	domain.Spec.Type = "hyperv"
 	log.Log.Infof("Adjusting domain for HyperV Layered")
 }
+
+func (*HyperVLayeredHypervisor) GetDevice() string {
+	return "mshv"
+}

--- a/pkg/hypervisor/hypervisor.go
+++ b/pkg/hypervisor/hypervisor.go
@@ -28,6 +28,9 @@ import (
 
 type Hypervisor interface {
 	AdjustDomain(vmi *v1.VirtualMachineInstance, domain *api.Domain)
+
+	// Returns the hypervisor device
+	GetDevice() string
 }
 
 func NewHypervisor(hypervisor string) Hypervisor {

--- a/pkg/hypervisor/kvm.go
+++ b/pkg/hypervisor/kvm.go
@@ -30,3 +30,7 @@ type KVMHypervisor struct{}
 func (k *KVMHypervisor) AdjustDomain(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
 	// no adjustments needed for KVM
 }
+
+func (*KVMHypervisor) GetDevice() string {
+	return "kvm"
+}

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
         "//pkg/host-disk:go_default_library",
         "//pkg/hotplug-disk:go_default_library",
+        "//pkg/hypervisor:go_default_library",
         "//pkg/libvmi:go_default_library",
         "//pkg/network/domainspec:go_default_library",
         "//pkg/network/errors:go_default_library",

--- a/pkg/virt-handler/device-manager/device_controller.go
+++ b/pkg/virt-handler/device-manager/device_controller.go
@@ -21,6 +21,7 @@ package device_manager
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"os"
 	"strings"
@@ -103,16 +104,16 @@ func (c *controlledDevice) GetName() string {
 	return c.devicePlugin.GetDeviceName()
 }
 
-func PermanentHostDevicePlugins(maxDevices int, permissions string) []Device {
+func PermanentHostDevicePlugins(hypervisorDevice string, maxDevices int, permissions string) []Device {
 	var permanentDevicePluginPaths = map[string]string{
-		"kvm":       "/dev/kvm",
-		"tun":       "/dev/net/tun",
-		"vhost-net": "/dev/vhost-net",
+		hypervisorDevice: fmt.Sprintf("/dev/%s", hypervisorDevice),
+		"tun":            "/dev/net/tun",
+		"vhost-net":      "/dev/vhost-net",
 	}
 
 	ret := make([]Device, 0, len(permanentDevicePluginPaths))
 	for name, path := range permanentDevicePluginPaths {
-		ret = append(ret, NewGenericDevicePlugin(name, path, maxDevices, permissions, name != "kvm"))
+		ret = append(ret, NewGenericDevicePlugin(name, path, maxDevices, permissions, name != hypervisorDevice))
 	}
 	return ret
 }

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -57,6 +57,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/executor"
 	hostdisk "kubevirt.io/kubevirt/pkg/host-disk"
 	hotplugdisk "kubevirt.io/kubevirt/pkg/hotplug-disk"
+	"kubevirt.io/kubevirt/pkg/hypervisor"
 	"kubevirt.io/kubevirt/pkg/network/domainspec"
 	neterrors "kubevirt.io/kubevirt/pkg/network/errors"
 	netsetup "kubevirt.io/kubevirt/pkg/network/setup"
@@ -222,11 +223,15 @@ func NewVirtualMachineController(
 		permissions = "rwm"
 	}
 
+	// Get the hypervisor device name from cluster config
+	hypervisorName := clusterConfig.GetConfig().HypervisorConfiguration.Name
+	hypervisor := hypervisor.NewHypervisor(hypervisorName)
+
 	c.deviceManagerController = deviceManager.NewDeviceController(
 		c.host,
 		maxDevices,
 		permissions,
-		deviceManager.PermanentHostDevicePlugins(maxDevices, permissions),
+		deviceManager.PermanentHostDevicePlugins(hypervisor.GetDevice(), maxDevices, permissions),
 		clusterConfig,
 		clientset.CoreV1())
 	c.heartBeat = heartbeat.NewHeartBeat(clientset.CoreV1(), c.deviceManagerController, clusterConfig, host)

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -135,6 +135,7 @@ go_test(
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",
         "//tests/framework/cleanup:go_default_library",
+        "//tests/framework/hypervisor:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/framework/matcher:go_default_library",
         "//tests/guestlog:go_default_library",

--- a/tests/framework/hypervisor/BUILD.bazel
+++ b/tests/framework/hypervisor/BUILD.bazel
@@ -6,10 +6,8 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests/framework/hypervisor",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/virt-config/featuregate:go_default_library",
-        "//pkg/virt-controller/services:go_default_library",
+        "//pkg/hypervisor:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests/libkubevirt:go_default_library",
-        "//vendor/k8s.io/api/core/v1:go_default_library",
     ],
 )

--- a/tests/framework/hypervisor/BUILD.bazel
+++ b/tests/framework/hypervisor/BUILD.bazel
@@ -7,7 +7,10 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/hypervisor:go_default_library",
+        "//pkg/virt-config:go_default_library",
+        "//pkg/virt-config/featuregate:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//tests/framework/checks:go_default_library",
         "//tests/libkubevirt:go_default_library",
     ],
 )

--- a/tests/framework/hypervisor/device.go
+++ b/tests/framework/hypervisor/device.go
@@ -23,6 +23,10 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/hypervisor"
+	virt_config "kubevirt.io/kubevirt/pkg/virt-config"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
+
+	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/libkubevirt"
 )
 
@@ -30,6 +34,10 @@ import (
 // based on the current KubeVirt configuration.
 func GetDevice(virtClient kubecli.KubevirtClient) string {
 	kv := libkubevirt.GetCurrentKv(virtClient)
-	hypervisorName := kv.Spec.Configuration.HypervisorConfiguration.Name
+	hypervisorName := virt_config.DefaultHypervisorName
+	if checks.HasFeature(featuregate.ConfigurableHypervisor) && kv.Spec.Configuration.HypervisorConfiguration != nil {
+		hypervisorName = kv.Spec.Configuration.HypervisorConfiguration.Name
+	}
 	return hypervisor.NewHypervisor(hypervisorName).GetDevice()
+
 }

--- a/tests/framework/hypervisor/device.go
+++ b/tests/framework/hypervisor/device.go
@@ -20,26 +20,16 @@
 package hypervisor
 
 import (
-	k8sv1 "k8s.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
-	"kubevirt.io/kubevirt/pkg/virt-controller/services"
+	"kubevirt.io/kubevirt/pkg/hypervisor"
 	"kubevirt.io/kubevirt/tests/libkubevirt"
 )
 
-// GetDevice returns the appropriate hypervisor device resource name
-// based on the current KubeVirt configuration. If HyperVLayered feature gate
-// is enabled, it returns HyperVDevice, otherwise KvmDevice.
-func GetDevice(virtClient kubecli.KubevirtClient) k8sv1.ResourceName {
+// GetDevice returns the appropriate hypervisor device name
+// based on the current KubeVirt configuration.
+func GetDevice(virtClient kubecli.KubevirtClient) string {
 	kv := libkubevirt.GetCurrentKv(virtClient)
-	if kv.Spec.Configuration.DeveloperConfiguration != nil {
-		featureGates := kv.Spec.Configuration.DeveloperConfiguration.FeatureGates
-		for _, fg := range featureGates {
-			if fg == featuregate.HyperVLayered {
-				return services.HyperVDevice
-			}
-		}
-	}
-	return services.KvmDevice
+	hypervisorName := kv.Spec.Configuration.HypervisorConfiguration.Name
+	return hypervisor.NewHypervisor(hypervisorName).GetDevice()
 }

--- a/tests/infrastructure/BUILD.bazel
+++ b/tests/infrastructure/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//tests/exec:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/checks:go_default_library",
+        "//tests/framework/hypervisor:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/framework/matcher:go_default_library",
         "//tests/libinfra:go_default_library",

--- a/tests/infrastructure/node-labeller.go
+++ b/tests/infrastructure/node-labeller.go
@@ -40,6 +40,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	nodelabellerutil "kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/util"
 	"kubevirt.io/kubevirt/tests/events"
+	"kubevirt.io/kubevirt/tests/framework/hypervisor"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libinfra"
 	"kubevirt.io/kubevirt/tests/libkubevirt"
@@ -60,14 +61,14 @@ var _ = Describe(SIGSerial("Node-labeller", func() {
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
-		nodesWithHypervisor = libnode.GetNodesWithHypervisor()
+		nodesWithHypervisor = libnode.GetNodesWithHypervisor(hypervisor.GetDevice(virtClient))
 		if len(nodesWithHypervisor) == 0 {
 			Fail("No nodes with hypervisor")
 		}
 	})
 
 	AfterEach(func() {
-		nodesWithHypervisor = libnode.GetNodesWithHypervisor()
+		nodesWithHypervisor = libnode.GetNodesWithHypervisor(hypervisor.GetDevice(virtClient))
 
 		for _, node := range nodesWithHypervisor {
 			libnode.RemoveLabelFromNode(node.Name, nonExistingCPUModelLabel)
@@ -143,7 +144,7 @@ var _ = Describe(SIGSerial("Node-labeller", func() {
 			config.UpdateKubeVirtConfigValueAndWait(kvConfig)
 
 			Eventually(func() bool {
-				nodesWithHypervisor = libnode.GetNodesWithHypervisor()
+				nodesWithHypervisor = libnode.GetNodesWithHypervisor(hypervisor.GetDevice(virtClient))
 
 				for _, node := range nodesWithHypervisor {
 					_, skipAnnotationFound := node.Annotations[v1.LabellerSkipNodeAnnotation]

--- a/tests/libnode/BUILD.bazel
+++ b/tests/libnode/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/util/nodes:go_default_library",
         "//pkg/virt-config:go_default_library",
+        "//pkg/virt-handler/device-manager:go_default_library",
         "//pkg/virt-operator/resource/generate/components:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",

--- a/tests/libnode/BUILD.bazel
+++ b/tests/libnode/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//tests/exec:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/cleanup:go_default_library",
-        "//tests/framework/hypervisor:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/libkubevirt:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/tests/libnode/node.go
+++ b/tests/libnode/node.go
@@ -48,7 +48,6 @@ import (
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/cleanup"
-	"kubevirt.io/kubevirt/tests/framework/hypervisor"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt"
 )
@@ -270,7 +269,7 @@ func Taint(nodeName, key string, effect k8sv1.TaintEffect) {
 	Expect(err).ToNot(HaveOccurred())
 }
 
-func GetNodesWithHypervisor() []*k8sv1.Node {
+func GetNodesWithHypervisor(hypervisorDevice string) []*k8sv1.Node {
 	virtClient := kubevirt.Client()
 	listOptions := k8smetav1.ListOptions{LabelSelector: v1.AppLabel + "=virt-handler"}
 	virtHandlerPods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), listOptions)
@@ -280,7 +279,7 @@ func GetNodesWithHypervisor() []*k8sv1.Node {
 
 	// Construct the K8s resource name for the hypervisor device
 	// Example: "devices.kubevirt.io/kvm"
-	hypervisorDevK8sResource := k8sv1.ResourceName(fmt.Sprintf("%s/%s", device_manager.DeviceNamespace, hypervisor.GetDevice(virtClient)))
+	hypervisorDevK8sResource := k8sv1.ResourceName(fmt.Sprintf("%s/%s", device_manager.DeviceNamespace, hypervisorDevice))
 
 	// cluster is not ready until all nodeList are ready.
 	for i := range virtHandlerPods.Items {

--- a/tests/operator/BUILD.bazel
+++ b/tests/operator/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/libvmi:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/virt-config/featuregate:go_default_library",
+        "//pkg/virt-handler/device-manager:go_default_library",
         "//pkg/virt-operator/resource/apply:go_default_library",
         "//pkg/virt-operator/resource/generate/components:go_default_library",
         "//pkg/virt-operator/util:go_default_library",

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -416,7 +416,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 			By("Test that worker nodes have the correct allocatable hypervisor devices according to virtualMachineInstancesPerNode setting")
 			hypervisorDevK8sResource := k8sv1.ResourceName(fmt.Sprintf("%s/%s", device_manager.DeviceNamespace, hypervisorDevice))
 			Eventually(func() error {
-				nodesWithHypervisor := libnode.GetNodesWithHypervisor()
+				nodesWithHypervisor := libnode.GetNodesWithHypervisor(hypervisorDevice)
 				for _, node := range nodesWithHypervisor {
 					devices, _ := node.Status.Allocatable[hypervisorDevK8sResource]
 					if int(devices.Value()) != newVirtualMachineInstancesPerNode {
@@ -442,7 +442,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 			defaultDevicesQuant := resource.MustParse(defaultDevices)
 
 			Eventually(func(g Gomega) {
-				nodesWithHypervisor := libnode.GetNodesWithHypervisor()
+				nodesWithHypervisor := libnode.GetNodesWithHypervisor(hypervisorDevice)
 				for _, node := range nodesWithHypervisor {
 					g.Expect(node.Status.Allocatable).To(HaveKeyWithValue(hypervisorDevK8sResource, defaultDevicesQuant), "node %s does not have the expected allocatable hypervisor devices", node.Name)
 				}

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -79,6 +79,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
+	device_manager "kubevirt.io/kubevirt/pkg/virt-handler/device-manager"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/apply"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 	"kubevirt.io/kubevirt/pkg/virt-operator/util"
@@ -413,12 +414,13 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 			testsuite.EnsureKubevirtReadyWithTimeout(kv, 120*time.Second)
 
 			By("Test that worker nodes have the correct allocatable hypervisor devices according to virtualMachineInstancesPerNode setting")
+			hypervisorDevK8sResource := k8sv1.ResourceName(fmt.Sprintf("%s/%s", device_manager.DeviceNamespace, hypervisorDevice))
 			Eventually(func() error {
 				nodesWithHypervisor := libnode.GetNodesWithHypervisor()
 				for _, node := range nodesWithHypervisor {
-					devices, _ := node.Status.Allocatable[hypervisorDevice]
+					devices, _ := node.Status.Allocatable[hypervisorDevK8sResource]
 					if int(devices.Value()) != newVirtualMachineInstancesPerNode {
-						return fmt.Errorf("node %s does not have the expected allocatable %s devices: %d, got: %d", node.Name, filepath.Base(string(hypervisorDevice)), newVirtualMachineInstancesPerNode, devices.Value())
+						return fmt.Errorf("node %s does not have the expected allocatable %s devices: %d, got: %d", node.Name, hypervisorDevice, newVirtualMachineInstancesPerNode, devices.Value())
 					}
 				}
 				return nil
@@ -438,12 +440,11 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 			By("Check that worker nodes resumed the default amount of allocatable hypervisor devices")
 			const defaultDevices = "1k"
 			defaultDevicesQuant := resource.MustParse(defaultDevices)
-			hypervisorDeviceKey := k8sv1.ResourceName(hypervisorDevice)
 
 			Eventually(func(g Gomega) {
 				nodesWithHypervisor := libnode.GetNodesWithHypervisor()
 				for _, node := range nodesWithHypervisor {
-					g.Expect(node.Status.Allocatable).To(HaveKeyWithValue(hypervisorDeviceKey, defaultDevicesQuant), "node %s does not have the expected allocatable hypervisor devices", node.Name)
+					g.Expect(node.Status.Allocatable).To(HaveKeyWithValue(hypervisorDevK8sResource, defaultDevicesQuant), "node %s does not have the expected allocatable hypervisor devices", node.Name)
 				}
 			}).WithTimeout(60 * time.Second).WithPolling(5 * time.Second).Should(Succeed())
 		})

--- a/tests/testsuite/BUILD.bazel
+++ b/tests/testsuite/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/util:go_default_library",
         "//pkg/virt-config/featuregate:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
+        "//pkg/virt-handler/device-manager:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/tests/testsuite/fixture.go
+++ b/tests/testsuite/fixture.go
@@ -44,6 +44,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
+	device_manager "kubevirt.io/kubevirt/pkg/virt-handler/device-manager"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/hypervisor"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
@@ -210,14 +211,13 @@ func shouldAllowEmulation(virtClient kubecli.KubevirtClient) bool {
 func EnsureHypervisorDevice() {
 	virtClient := kubevirt.Client()
 
-	device := hypervisor.GetDevice(virtClient)
+	deviceName := hypervisor.GetDevice(virtClient)
+	deviceK8sResource := k8sv1.ResourceName(fmt.Sprintf("%s/%s", device_manager.DeviceNamespace, deviceName))
 
 	if !shouldAllowEmulation(virtClient) {
 		listOptions := metav1.ListOptions{LabelSelector: v1.AppLabel + "=virt-handler"}
 		virtHandlerPods, err := virtClient.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), listOptions)
 		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-
-		deviceName := filepath.Base(string(device))
 
 		EventuallyWithOffset(1, func() bool {
 			ready := true
@@ -226,7 +226,7 @@ func EnsureHypervisorDevice() {
 				virtHandlerNode, err := virtClient.CoreV1().Nodes().Get(context.Background(), pod.Spec.NodeName, metav1.GetOptions{})
 				ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
-				allocatable, ok1 := virtHandlerNode.Status.Allocatable[device]
+				allocatable, ok1 := virtHandlerNode.Status.Allocatable[deviceK8sResource]
 				vhostNetAllocatable, ok2 := virtHandlerNode.Status.Allocatable[services.VhostNetDevice]
 				ready = ready && ok1 && ok2
 				ready = ready && (allocatable.Value() > 0) && (vhostNetAllocatable.Value() > 0)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This PR lets virt-handler setup the device plugin for the hypervisor based on the HypervisorConfiguration field in KubevirtConfiguration. It does so by adding a function called `GetDevice()` in the Hypervisor interface, which returns the device name exposed by the kernel for accessing the hypervisor. Note that the return value of the `GetDevice()` function does not contain the `/dev/` prefix. So for the KVM hypervisor, whereas the kernel exposes device `/dev/kvm`, the interface implementation would return only `kvm`.

It also updates the tests to use the value returned by the `GetDevice()` function. The  feature-gate based logic of which hypervisor device to return has been replaced with checking the KubevirtConfiguration.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

