### PR TITLE
Use correct hypervisor device in handler and launcher

### DIFF
--- a/pkg/virt-handler/controller.go
+++ b/pkg/virt-handler/controller.go
@@ -196,17 +196,25 @@ func (c *BaseController) isMigrationSource(vmi *v1.VirtualMachineInstance) bool 
 		!vmi.Status.MigrationState.Completed
 }
 
-func (c *BaseController) claimDeviceOwnership(virtLauncherRootMount *safepath.Path, deviceName string) error {
+func (c *BaseController) tryClaimDeviceOwnership(virtLauncherRootMount *safepath.Path, deviceName string, ignoreErrorWithEmulation bool) error {
 	softwareEmulation := c.clusterConfig.AllowEmulation()
 	devicePath, err := safepath.JoinNoFollow(virtLauncherRootMount, filepath.Join("dev", deviceName))
 	if err != nil {
-		if softwareEmulation && deviceName == "kvm" {
+		if softwareEmulation && ignoreErrorWithEmulation {
 			return nil
 		}
 		return err
 	}
 
 	return diskutils.DefaultOwnershipManager.SetFileOwnership(devicePath)
+}
+
+func (c *BaseController) claimDeviceOwnership(virtLauncherRootMount *safepath.Path, deviceName string) error {
+	return c.tryClaimDeviceOwnership(virtLauncherRootMount, deviceName, false)
+}
+
+func (c *BaseController) claimHypervisorDeviceOwnership(virtLauncherRootMount *safepath.Path, deviceName string) error {
+	return c.tryClaimDeviceOwnership(virtLauncherRootMount, deviceName, true)
 }
 
 func (c *BaseController) configureHostDisks(
@@ -249,7 +257,7 @@ func (c *BaseController) configureVirtioFS(vmi *v1.VirtualMachineInstance, isola
 	return nil
 }
 
-func (c *BaseController) setupDevicesOwnerships(vmi *v1.VirtualMachineInstance, recorder record.EventRecorder) error {
+func (c *BaseController) setupDevicesOwnerships(vmi *v1.VirtualMachineInstance, recorder record.EventRecorder, hypervisorDevice string) error {
 	isolationRes, err := c.podIsolationDetector.Detect(vmi)
 	if err != nil {
 		return fmt.Errorf(failedDetectIsolationFmt, err)
@@ -260,9 +268,9 @@ func (c *BaseController) setupDevicesOwnerships(vmi *v1.VirtualMachineInstance, 
 		return err
 	}
 
-	err = c.claimDeviceOwnership(virtLauncherRootMount, "kvm")
+	err = c.claimHypervisorDeviceOwnership(virtLauncherRootMount, hypervisorDevice)
 	if err != nil {
-		return fmt.Errorf("failed to set up file ownership for /dev/kvm: %v", err)
+		return fmt.Errorf("failed to set up file ownership for /dev/%s: %v", hypervisorDevice, err)
 	}
 
 	if util.IsAutoAttachVSOCK(vmi) {

--- a/pkg/virt-handler/migration-target.go
+++ b/pkg/virt-handler/migration-target.go
@@ -50,6 +50,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/controller"
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	hostdisk "kubevirt.io/kubevirt/pkg/host-disk"
+	"kubevirt.io/kubevirt/pkg/hypervisor"
 	"kubevirt.io/kubevirt/pkg/network/domainspec"
 	netsetup "kubevirt.io/kubevirt/pkg/network/setup"
 	"kubevirt.io/kubevirt/pkg/pointer"
@@ -708,7 +709,7 @@ func (c *MigrationTargetController) processVMI(vmi *v1.VirtualMachineInstance) e
 		return fmt.Errorf("failed to configure vmi network for migration target: %w", err)
 	}
 
-	if err := c.setupDevicesOwnerships(vmi, c.recorder); err != nil {
+	if err := c.setupDevicesOwnerships(vmi, c.recorder, hypervisor.NewHypervisor(c.clusterConfig.GetHypervisor().Name).GetDevice()); err != nil {
 		return err
 	}
 

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -2050,7 +2050,7 @@ func (c *VirtualMachineController) handleStartingVMI(
 		return false, fmt.Errorf("failed to configure vmi network: %w", err)
 	}
 
-	if err := c.setupDevicesOwnerships(vmi, c.recorder); err != nil {
+	if err := c.setupDevicesOwnerships(vmi, c.recorder, hypervisor.NewHypervisor(c.clusterConfig.GetHypervisor().Name).GetDevice()); err != nil {
 		return false, err
 	}
 

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -2894,7 +2894,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 
 			p, err := safepath.JoinAndResolveWithRelativeRoot("/", path)
 			Expect(err).ToNot(HaveOccurred())
-			err = controller.claimDeviceOwnership(p, "kvm")
+			err = controller.claimHypervisorDeviceOwnership(p, "kvm")
 			if softEmulation {
 				Expect(err).NotTo(HaveOccurred())
 			} else {

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1465,14 +1465,17 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		domainVCPUTopologyForHotplug(vmi, domain)
 	}
 
-	kvmPath := "/dev/kvm"
-	if _, err := os.Stat(kvmPath); errors.Is(err, os.ErrNotExist) {
+	hypervisorPath := "/dev/kvm"
+	if c.Hypervisor != nil {
+		hypervisorPath = fmt.Sprintf("/dev/%s", c.Hypervisor.GetDevice())
+	}
+	if _, err := os.Stat(hypervisorPath); errors.Is(err, os.ErrNotExist) {
 		if c.AllowEmulation {
 			logger := log.DefaultLogger()
-			logger.Infof("Hardware emulation device '%s' not present. Using software emulation.", kvmPath)
+			logger.Infof("Hardware emulation device '%s' not present. Using software emulation.", hypervisorPath)
 			domain.Spec.Type = "qemu"
 		} else {
-			return fmt.Errorf("hardware emulation device '%s' not present", kvmPath)
+			return fmt.Errorf("hardware emulation device '%s' not present", hypervisorPath)
 		}
 	} else if err != nil {
 		return err


### PR DESCRIPTION
### What this PR does

- `virt-handler` now uses the right hypervisor dev to claim ownership to qemu user 

- `virt-launcher` uses the right device to check existence and set `domain.spec.type`

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #48 

-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->